### PR TITLE
STA-7: Configure Maven Central publishing for alpha release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     
     steps:
     - uses: actions/checkout@v4
@@ -53,11 +53,37 @@ jobs:
         branch: main
         tags: true
     
-    # Maven Central publishing would go here when configured
-    # - name: Publish to Maven Central
-    #   run: ./gradlew publish --no-daemon
-    #   env:
-    #     ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-    #     ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-    #     ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-    #     ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+    - name: Publish to Maven Central
+      run: ./gradlew publish --no-daemon
+      env:
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+    
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: "v${{ github.event.inputs.version }}"
+        release_name: "Release v${{ github.event.inputs.version }}"
+        body: |
+          ## StateHolder KMP v${{ github.event.inputs.version }}
+          
+          ### Published Modules
+          - `io.github.rentoyokawa:stateholder-annotations:${{ github.event.inputs.version }}`
+          - `io.github.rentoyokawa:stateholder-core:${{ github.event.inputs.version }}`
+          - `io.github.rentoyokawa:stateholder-viewmodel-koin:${{ github.event.inputs.version }}`
+          - `io.github.rentoyokawa:stateholder-processor-koin:${{ github.event.inputs.version }}`
+          
+          ### Usage
+          ```kotlin
+          dependencies {
+              implementation("io.github.rentoyokawa:stateholder-core:${{ github.event.inputs.version }}")
+              implementation("io.github.rentoyokawa:stateholder-viewmodel-koin:${{ github.event.inputs.version }}")
+              ksp("io.github.rentoyokawa:stateholder-processor-koin:${{ github.event.inputs.version }}")
+          }
+          ```
+        draft: false
+        prerelease: ${{ contains(github.event.inputs.version, 'alpha') || contains(github.event.inputs.version, 'beta') || contains(github.event.inputs.version, 'rc') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to the StateHolder KMP project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha01] - 2024-08-30
+
+### Added
+- Initial alpha release of StateHolder KMP library
+- Core StateHolder implementation for state management
+- KSP processor with Koin dependency injection support
+- ViewModel integration for Android and Compose Multiplatform
+- Annotations for code generation (`@StateHolder`, `@SharedState`, `@InjectedParam`)
+- Support for Kotlin Multiplatform targets:
+  - Android (minSdk 24)
+  - JVM (target 17)
+  - iOS (iosX64, iosArm64, iosSimulatorArm64)
+- XCFramework generation for iOS integration
+- Maven Central publishing with GPG signing
+- Comprehensive documentation in English and Japanese
+
+### Features
+- **StateHolder Pattern**: Clean separation of UI state management from ViewModels
+- **SharedState**: Cross-StateHolder state sharing within ViewModel scope
+- **Code Generation**: Automatic parameter provider and Koin module generation
+- **Type Safety**: Full Kotlin type safety with compile-time validation
+- **Testing Support**: Comprehensive test utilities and examples
+
+### Technical Details
+- Kotlin 2.0.10
+- Coroutines 1.8.1 
+- KSP 2.0.10-1.0.24
+- Koin 3.5.6
+- Built with standard Gradle `maven-publish` plugin
+
+### Published Modules
+- `io.github.rentoyokawa:stateholder-annotations:0.1.0-alpha01`
+- `io.github.rentoyokawa:stateholder-core:0.1.0-alpha01`
+- `io.github.rentoyokawa:stateholder-viewmodel-koin:0.1.0-alpha01`
+- `io.github.rentoyokawa:stateholder-processor-koin:0.1.0-alpha01`
+
+[Unreleased]: https://github.com/Ren-Toyokawa/stateholder-kmp/compare/v0.1.0-alpha01...HEAD
+[0.1.0-alpha01]: https://github.com/Ren-Toyokawa/stateholder-kmp/releases/tag/v0.1.0-alpha01

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,133 @@
+# Publishing StateHolder KMP
+
+This document explains the CI/CD-based publishing process for StateHolder KMP library to Maven Central.
+
+## Overview
+
+**All releases are automated through GitHub Actions** - no manual publishing from local development environment.
+
+## Prerequisites
+
+### Maven Central Account
+
+1. Create an account at [central.sonatype.com](https://central.sonatype.com/)
+2. Request access for the `io.github.rentoyokawa` namespace
+
+### GPG Signing Key
+
+1. Generate a GPG key pair:
+   ```bash
+   gpg --full-generate-key
+   ```
+
+2. Export the private key:
+   ```bash
+   gpg --armor --export-secret-keys YOUR_KEY_ID > signing-key.asc
+   ```
+
+3. Get the key ID:
+   ```bash
+   gpg --list-secret-keys --keyid-format LONG
+   ```
+
+## Repository Secrets
+
+Set up the following secrets in GitHub repository settings:
+
+- `MAVEN_CENTRAL_USERNAME`: Your Sonatype username
+- `MAVEN_CENTRAL_PASSWORD`: Your Sonatype password (or token) 
+- `SIGNING_KEY`: Contents of your `signing-key.asc` file
+- `SIGNING_PASSWORD`: Passphrase for your GPG key
+
+## Local Development
+
+For local development, **only use Maven Local**:
+
+```bash
+# Build project
+./gradlew clean build
+
+# Publish to local Maven repository (no signing required)
+./gradlew publishToMavenLocal
+
+# Verify artifacts
+ls -la ~/.m2/repository/io/github/rentoyokawa/
+```
+
+**Note**: Local publishing does not require signing - it's automatically skipped when signing keys are not available.
+
+## Release Process
+
+### CI/CD Release Process
+
+1. Go to GitHub Actions in the repository
+2. Select "Release" workflow
+3. Click "Run workflow"
+4. Enter the version number (e.g., `0.1.0-alpha01`)
+5. Click "Run workflow"
+
+The automated workflow will:
+- Update version numbers in `build.gradle.kts`
+- Build and test the project
+- Sign artifacts using GPG keys from GitHub Secrets
+- Publish to Maven Central S01 repository
+- Create a git tag and GitHub release
+- Push changes back to main branch
+
+### Security Features
+
+- **Environment-based signing**: Only signs artifacts when running in CI with proper secrets
+- **Automatic prerelease detection**: Alpha/beta/rc versions are marked as prerelease in GitHub
+- **Credential isolation**: No sensitive data stored in local development environment
+
+## Published Modules
+
+The following modules are published to Maven Central using standard Gradle `maven-publish` plugin:
+
+- `io.github.rentoyokawa:stateholder-annotations` - Annotations for code generation
+- `io.github.rentoyokawa:stateholder-core` - Core StateHolder implementation  
+- `io.github.rentoyokawa:stateholder-viewmodel-koin` - ViewModel integration with Koin
+- `io.github.rentoyokawa:stateholder-processor-koin` - KSP processor with Koin support
+
+All modules are configured with:
+- Sources JAR publication
+- Javadoc JAR publication (for JVM modules)
+- GPG signing for Maven Central requirements
+- Proper POM metadata
+
+## Usage in Projects
+
+After publishing via CI/CD, users can add the library to their projects:
+
+```kotlin
+// In build.gradle.kts
+dependencies {
+    implementation("io.github.rentoyokawa:stateholder-core:0.1.0-alpha01")
+    implementation("io.github.rentoyokawa:stateholder-viewmodel-koin:0.1.0-alpha01")
+    ksp("io.github.rentoyokawa:stateholder-processor-koin:0.1.0-alpha01")
+}
+```
+
+Each GitHub release will include the usage instructions with the specific version number.
+
+## Troubleshooting
+
+### Publication Issues
+
+1. **Signing errors**: Verify GPG key and passphrase are correct
+2. **Authentication errors**: Check Maven Central credentials
+3. **Namespace errors**: Ensure you have access to `io.github.rentoyokawa`
+
+### Local Testing
+
+If local publishing fails, check:
+- All modules build successfully
+- No missing dependencies
+- Gradle properties are properly set
+
+### GitHub Actions
+
+Check the workflow logs for detailed error messages. Common issues:
+- Missing repository secrets
+- Invalid GPG key format
+- Network connectivity issues with Maven Central

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
     group = "io.github.rentoyokawa"
-    version = "0.1.0-SNAPSHOT"
+    version = "0.1.0-alpha01"
     
     repositories {
         google()
@@ -18,5 +18,5 @@ allprojects {
 }
 
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,14 +12,7 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.defaults.buildfeatures.buildconfig=false
 
-# Maven Publishing (将来の公開用)
-SONATYPE_HOST=S01
-RELEASE_SIGNING_ENABLED=true
-GROUP=io.github.rentoyokawa
-POM_ARTIFACT_ID=stateholder-kmp
-VERSION_NAME=0.1.0-SNAPSHOT
-
-POM_NAME=StateHolder KMP
+# Maven Publishing - POM metadata
 POM_DESCRIPTION=A Kotlin Multiplatform library for state management with KSP code generation
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/Ren-Toyokawa/stateholder-kmp

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ koin = "3.5.6"
 # Code generation
 kotlinpoet = "1.16.0"
 
+# Documentation
+dokka = "1.9.20"
+
 # Testing
 junit = "4.13.2"
 kotlin-compile-testing = "1.6.0"
@@ -59,3 +62,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }

--- a/stateholder-annotations/build.gradle.kts
+++ b/stateholder-annotations/build.gradle.kts
@@ -1,7 +1,12 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+    alias(libs.plugins.dokka)
+    `maven-publish`
+    signing
 }
+
+description = "Annotations for StateHolder KMP code generation"
 
 android {
     namespace = "io.github.rentoyokawa.stateholder.annotations"
@@ -14,6 +19,13 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+    
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
 }
 
@@ -38,6 +50,13 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     
+    // iOS Framework configuration
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+        binaries.framework {
+            baseName = "StateHolderAnnotations"
+        }
+    }
+    
     sourceSets {
         commonMain {
             dependencies {
@@ -50,5 +69,66 @@ kotlin {
                 implementation(kotlin("test"))
             }
         }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "Central"
+            val releaseRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            val snapshotRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotRepoUrl else releaseRepoUrl)
+            credentials {
+                username = System.getenv("MAVEN_CENTRAL_USERNAME") ?: providers.gradleProperty("mavenCentralUsername").orNull
+                password = System.getenv("MAVEN_CENTRAL_PASSWORD") ?: providers.gradleProperty("mavenCentralPassword").orNull
+            }
+        }
+    }
+    
+    publications.withType<MavenPublication> {
+        artifactId = "stateholder-annotations"
+        
+        pom {
+            name.set("StateHolder KMP Annotations")
+            description.set(project.description)
+            inceptionYear.set(providers.gradleProperty("POM_INCEPTION_YEAR"))
+            url.set(providers.gradleProperty("POM_URL"))
+            
+            licenses {
+                license {
+                    name.set(providers.gradleProperty("POM_LICENSE_NAME"))
+                    url.set(providers.gradleProperty("POM_LICENSE_URL"))
+                    distribution.set(providers.gradleProperty("POM_LICENSE_DIST"))
+                }
+            }
+            
+            developers {
+                developer {
+                    id.set(providers.gradleProperty("POM_DEVELOPER_ID"))
+                    name.set(providers.gradleProperty("POM_DEVELOPER_NAME"))
+                    url.set(providers.gradleProperty("POM_DEVELOPER_URL"))
+                }
+            }
+            
+            scm {
+                url.set(providers.gradleProperty("POM_SCM_URL"))
+                connection.set(providers.gradleProperty("POM_SCM_CONNECTION"))
+                developerConnection.set(providers.gradleProperty("POM_SCM_DEV_CONNECTION"))
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey = System.getenv("SIGNING_KEY") ?: providers.gradleProperty("signingInMemoryKey").orNull
+    val signingPassword = System.getenv("SIGNING_PASSWORD") ?: providers.gradleProperty("signingInMemoryKeyPassword").orNull
+    
+    // Only require signing for releases and when keys are available
+    isRequired = !version.toString().endsWith("SNAPSHOT") && signingKey != null
+    
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications)
     }
 }

--- a/stateholder-core/build.gradle.kts
+++ b/stateholder-core/build.gradle.kts
@@ -2,7 +2,12 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
+    alias(libs.plugins.dokka)
+    `maven-publish`
+    signing
 }
+
+description = "Core StateHolder implementation for Kotlin Multiplatform"
 
 android {
     namespace = "io.github.rentoyokawa.stateholder"
@@ -15,6 +20,13 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+    
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
 }
 
@@ -39,6 +51,13 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     
+    // iOS Framework configuration
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+        binaries.framework {
+            baseName = "StateHolderCore"
+        }
+    }
+    
     sourceSets {
         commonMain {
             dependencies {
@@ -55,5 +74,66 @@ kotlin {
                 implementation("app.cash.turbine:turbine:1.1.0")
             }
         }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "Central"
+            val releaseRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            val snapshotRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotRepoUrl else releaseRepoUrl)
+            credentials {
+                username = System.getenv("MAVEN_CENTRAL_USERNAME") ?: providers.gradleProperty("mavenCentralUsername").orNull
+                password = System.getenv("MAVEN_CENTRAL_PASSWORD") ?: providers.gradleProperty("mavenCentralPassword").orNull
+            }
+        }
+    }
+    
+    publications.withType<MavenPublication> {
+        artifactId = "stateholder-core"
+        
+        pom {
+            name.set("StateHolder KMP Core")
+            description.set(project.description)
+            inceptionYear.set(providers.gradleProperty("POM_INCEPTION_YEAR"))
+            url.set(providers.gradleProperty("POM_URL"))
+            
+            licenses {
+                license {
+                    name.set(providers.gradleProperty("POM_LICENSE_NAME"))
+                    url.set(providers.gradleProperty("POM_LICENSE_URL"))
+                    distribution.set(providers.gradleProperty("POM_LICENSE_DIST"))
+                }
+            }
+            
+            developers {
+                developer {
+                    id.set(providers.gradleProperty("POM_DEVELOPER_ID"))
+                    name.set(providers.gradleProperty("POM_DEVELOPER_NAME"))
+                    url.set(providers.gradleProperty("POM_DEVELOPER_URL"))
+                }
+            }
+            
+            scm {
+                url.set(providers.gradleProperty("POM_SCM_URL"))
+                connection.set(providers.gradleProperty("POM_SCM_CONNECTION"))
+                developerConnection.set(providers.gradleProperty("POM_SCM_DEV_CONNECTION"))
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey = System.getenv("SIGNING_KEY") ?: providers.gradleProperty("signingInMemoryKey").orNull
+    val signingPassword = System.getenv("SIGNING_PASSWORD") ?: providers.gradleProperty("signingInMemoryKeyPassword").orNull
+    
+    // Only require signing for releases and when keys are available
+    isRequired = !version.toString().endsWith("SNAPSHOT") && signingKey != null
+    
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications)
     }
 }

--- a/stateholder-processor-koin/build.gradle.kts
+++ b/stateholder-processor-koin/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.dokka)
+    `maven-publish`
+    signing
 }
 
 kotlin {
@@ -31,4 +34,73 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinpoet)
     testImplementation(libs.mockk)
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "Central"
+            val releaseRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            val snapshotRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotRepoUrl else releaseRepoUrl)
+            credentials {
+                username = System.getenv("MAVEN_CENTRAL_USERNAME") ?: providers.gradleProperty("mavenCentralUsername").orNull
+                password = System.getenv("MAVEN_CENTRAL_PASSWORD") ?: providers.gradleProperty("mavenCentralPassword").orNull
+            }
+        }
+    }
+    
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+            artifactId = "stateholder-processor-koin"
+            
+            pom {
+                name.set("StateHolder KMP Processor Koin")
+                description.set("KSP processor for StateHolder code generation with Koin support")
+                inceptionYear.set(providers.gradleProperty("POM_INCEPTION_YEAR"))
+                url.set(providers.gradleProperty("POM_URL"))
+                
+                licenses {
+                    license {
+                        name.set(providers.gradleProperty("POM_LICENSE_NAME"))
+                        url.set(providers.gradleProperty("POM_LICENSE_URL"))
+                        distribution.set(providers.gradleProperty("POM_LICENSE_DIST"))
+                    }
+                }
+                
+                developers {
+                    developer {
+                        id.set(providers.gradleProperty("POM_DEVELOPER_ID"))
+                        name.set(providers.gradleProperty("POM_DEVELOPER_NAME"))
+                        url.set(providers.gradleProperty("POM_DEVELOPER_URL"))
+                    }
+                }
+                
+                scm {
+                    url.set(providers.gradleProperty("POM_SCM_URL"))
+                    connection.set(providers.gradleProperty("POM_SCM_CONNECTION"))
+                    developerConnection.set(providers.gradleProperty("POM_SCM_DEV_CONNECTION"))
+                }
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey = System.getenv("SIGNING_KEY") ?: providers.gradleProperty("signingInMemoryKey").orNull
+    val signingPassword = System.getenv("SIGNING_PASSWORD") ?: providers.gradleProperty("signingInMemoryKeyPassword").orNull
+    
+    // Only require signing for releases and when keys are available
+    isRequired = !version.toString().endsWith("SNAPSHOT") && signingKey != null
+    
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications)
+    }
 }

--- a/stateholder-viewmodel-koin/build.gradle.kts
+++ b/stateholder-viewmodel-koin/build.gradle.kts
@@ -1,7 +1,12 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+    alias(libs.plugins.dokka)
+    `maven-publish`
+    signing
 }
+
+description = "ViewModel integration for StateHolder with Koin dependency injection"
 
 android {
     namespace = "io.github.rentoyokawa.stateholder.viewmodel"
@@ -14,6 +19,13 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+    
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
 }
 
@@ -38,6 +50,13 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     
+    // iOS Framework configuration
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+        binaries.framework {
+            baseName = "StateHolderViewModelKoin"
+        }
+    }
+    
     sourceSets {
         commonMain {
             dependencies {
@@ -55,5 +74,66 @@ kotlin {
                 implementation(kotlin("test"))
             }
         }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "Central"
+            val releaseRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            val snapshotRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotRepoUrl else releaseRepoUrl)
+            credentials {
+                username = System.getenv("MAVEN_CENTRAL_USERNAME") ?: providers.gradleProperty("mavenCentralUsername").orNull
+                password = System.getenv("MAVEN_CENTRAL_PASSWORD") ?: providers.gradleProperty("mavenCentralPassword").orNull
+            }
+        }
+    }
+    
+    publications.withType<MavenPublication> {
+        artifactId = "stateholder-viewmodel-koin"
+        
+        pom {
+            name.set("StateHolder KMP ViewModel Koin")
+            description.set(project.description)
+            inceptionYear.set(providers.gradleProperty("POM_INCEPTION_YEAR"))
+            url.set(providers.gradleProperty("POM_URL"))
+            
+            licenses {
+                license {
+                    name.set(providers.gradleProperty("POM_LICENSE_NAME"))
+                    url.set(providers.gradleProperty("POM_LICENSE_URL"))
+                    distribution.set(providers.gradleProperty("POM_LICENSE_DIST"))
+                }
+            }
+            
+            developers {
+                developer {
+                    id.set(providers.gradleProperty("POM_DEVELOPER_ID"))
+                    name.set(providers.gradleProperty("POM_DEVELOPER_NAME"))
+                    url.set(providers.gradleProperty("POM_DEVELOPER_URL"))
+                }
+            }
+            
+            scm {
+                url.set(providers.gradleProperty("POM_SCM_URL"))
+                connection.set(providers.gradleProperty("POM_SCM_CONNECTION"))
+                developerConnection.set(providers.gradleProperty("POM_SCM_DEV_CONNECTION"))
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey = System.getenv("SIGNING_KEY") ?: providers.gradleProperty("signingInMemoryKey").orNull
+    val signingPassword = System.getenv("SIGNING_PASSWORD") ?: providers.gradleProperty("signingInMemoryKeyPassword").orNull
+    
+    // Only require signing for releases and when keys are available
+    isRequired = !version.toString().endsWith("SNAPSHOT") && signingKey != null
+    
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for CI/CD-based publishing process
- Create CHANGELOG.md with detailed release notes for v0.1.0-alpha01
- Add PUBLISHING.md with complete Maven Central publishing setup instructions
- Document GPG signing configuration and GitHub Secrets setup
- Provide local development guidelines using Maven Local

## Test plan
- [ ] Verify CHANGELOG.md format follows Keep a Changelog standards
- [ ] Review PUBLISHING.md documentation for accuracy
- [ ] Test local publishing with `./gradlew publishToMavenLocal`
- [ ] Validate GitHub Actions workflow configuration
- [ ] Configure required GitHub Secrets before release