### PR TITLE
Add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- Add workflow_dispatch trigger to release.yml to enable manual execution

## Test plan
- Verify workflow can be manually triggered from GitHub Actions UI