### PR TITLE
Add comprehensive POM configuration for Maven Central publishing

### DIFF
--- a/stateholder-annotations/build.gradle.kts
+++ b/stateholder-annotations/build.gradle.kts
@@ -74,4 +74,30 @@ kotlin {
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
+    
+    pom {
+        name = "StateHolder Annotations"
+        description = "Annotations for StateHolder KSP code generation"
+        inceptionYear = "2024"
+        url = "https://github.com/Ren-Toyokawa/stateholder-kmp"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = "rentoyokawa"
+                name = "Ren Toyokawa"
+                url = "https://github.com/Ren-Toyokawa/"
+            }
+        }
+        scm {
+            url = "https://github.com/Ren-Toyokawa/stateholder-kmp"
+            connection = "scm:git:git://github.com/Ren-Toyokawa/stateholder-kmp.git"
+            developerConnection = "scm:git:ssh://git@github.com/Ren-Toyokawa/stateholder-kmp.git"
+        }
+    }
 }

--- a/stateholder-core/build.gradle.kts
+++ b/stateholder-core/build.gradle.kts
@@ -79,4 +79,30 @@ kotlin {
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
+    
+    pom {
+        name = "StateHolder Core"
+        description = "Core StateHolder implementation for Kotlin Multiplatform"
+        inceptionYear = "2024"
+        url = "https://github.com/Ren-Toyokawa/stateholder-kmp"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = "rentoyokawa"
+                name = "Ren Toyokawa"
+                url = "https://github.com/Ren-Toyokawa/"
+            }
+        }
+        scm {
+            url = "https://github.com/Ren-Toyokawa/stateholder-kmp"
+            connection = "scm:git:git://github.com/Ren-Toyokawa/stateholder-kmp.git"
+            developerConnection = "scm:git:ssh://git@github.com/Ren-Toyokawa/stateholder-kmp.git"
+        }
+    }
 }

--- a/stateholder-processor-koin/build.gradle.kts
+++ b/stateholder-processor-koin/build.gradle.kts
@@ -39,4 +39,30 @@ dependencies {
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
+    
+    pom {
+        name = "StateHolder Processor Koin"
+        description = "KSP processor for StateHolder with Koin support"
+        inceptionYear = "2024"
+        url = "https://github.com/Ren-Toyokawa/stateholder-kmp"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = "rentoyokawa"
+                name = "Ren Toyokawa"
+                url = "https://github.com/Ren-Toyokawa/"
+            }
+        }
+        scm {
+            url = "https://github.com/Ren-Toyokawa/stateholder-kmp"
+            connection = "scm:git:git://github.com/Ren-Toyokawa/stateholder-kmp.git"
+            developerConnection = "scm:git:ssh://git@github.com/Ren-Toyokawa/stateholder-kmp.git"
+        }
+    }
 }

--- a/stateholder-viewmodel-koin/build.gradle.kts
+++ b/stateholder-viewmodel-koin/build.gradle.kts
@@ -79,4 +79,30 @@ kotlin {
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
+    
+    pom {
+        name = "StateHolder ViewModel Koin"
+        description = "ViewModel integration for StateHolder with Koin dependency injection"
+        inceptionYear = "2024"
+        url = "https://github.com/Ren-Toyokawa/stateholder-kmp"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = "rentoyokawa"
+                name = "Ren Toyokawa"
+                url = "https://github.com/Ren-Toyokawa/"
+            }
+        }
+        scm {
+            url = "https://github.com/Ren-Toyokawa/stateholder-kmp"
+            connection = "scm:git:git://github.com/Ren-Toyokawa/stateholder-kmp.git"
+            developerConnection = "scm:git:ssh://git@github.com/Ren-Toyokawa/stateholder-kmp.git"
+        }
+    }
 }


### PR DESCRIPTION
## Summary
• Add complete POM metadata configuration for Maven Central publishing requirements
• Configure consistent project information across all publishable modules
• Set up proper developer and SCM information for repository

## Changes Made
• **stateholder-annotations**: Added POM with name "StateHolder Annotations" and description for KSP annotation definitions
• **stateholder-core**: Added POM with name "StateHolder Core" for core StateHolder implementation
• **stateholder-processor-koin**: Added POM with name "StateHolder Processor Koin" for KSP processor with Koin support
• **stateholder-viewmodel-koin**: Added POM with name "StateHolder ViewModel Koin" for ViewModel integration

## POM Configuration Details
Each module now includes:
- Project name and description specific to the module's purpose
- Apache License 2.0 configuration
- Developer information (Ren Toyokawa)
- SCM connections to GitHub repository
- Inception year set to 2024

## Test Plan
- [x] Verify build.gradle.kts syntax is correct
- [x] Test Maven publishing configuration with `./gradlew publishToMavenLocal`
- [x] Validate POM generation includes all required metadata
- [x] Confirm no breaking changes to existing build process

This ensures all modules meet Maven Central publishing requirements and provide proper metadata for consumers.