### PR TITLE
STA-12: CI を再稼働させる（upload-artifact v3→v4 移行と build/lint 復活）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,14 @@ jobs:
       run: ./gradlew test --no-daemon
     
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results
         path: '**/build/test-results/**/*.xml'
-    
+
     - name: Upload reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Temporarily disabled: actions/upload-artifact@v3 is deprecated and hard-fails
-    # at "Set up job". Re-enable after migrating to v4. Tracked in STA follow-up ticket.
-    if: ${{ false }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    # Temporarily disabled together with the build job. Re-enable in the CI follow-up ticket.
-    if: ${{ false }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要
[STA-12](https://linear.app/issue/STA-12) - CI の `build`/`lint` ジョブに付けた暫定無効化ガード（`if: ${{ false }}`）を解除し、`actions/upload-artifact@v3`（非推奨・自動fail）を `@v4` へ移行して CI を再稼働させる。

## 主な変更
- `.github/workflows/ci.yml`
  - `build` / `lint` ジョブの `if: ${{ false }}` 暫定ガード削除
  - `build` ジョブ内 2 箇所の `actions/upload-artifact@v3` → `@v4`

## 参照
- intent: `~/Github/claude-brain/StateHolder/flows/STA-12.md`
- plan: `~/Github/claude-brain/StateHolder/flows/STA-12.plan.md`

## 注意
- iOS ターゲット × ubuntu ランナーで `build`/`test` が失敗する可能性あり（スコープ外、要切り分け）。詳細は intent 参照。