### PR TITLE
[STA-19] サンプルを生成 Koin モジュールで駆動（e2e 実証）

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,8 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 
 # Koin
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin" }
 

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -32,6 +33,8 @@ android {
 
 dependencies {
     implementation(project(":stateholder-core"))
+    implementation(project(":stateholder-annotations"))
+    ksp(project(":stateholder-processor-koin"))
 
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.material3)
@@ -41,4 +44,12 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
+
+    implementation(libs.koin.android)
+    implementation(libs.koin.androidx.compose)
+}
+
+ksp {
+    arg("stateholder.module.suffix", "sample")
+    arg("stateholder.module.package", "io.github.rentoyokawa.stateholder.sample.di")
 }

--- a/samples/android/src/main/AndroidManifest.xml
+++ b/samples/android/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".SampleApplication"
         android:label="StateHolder Sample"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity

--- a/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/SampleApplication.kt
+++ b/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/SampleApplication.kt
@@ -1,0 +1,29 @@
+package io.github.rentoyokawa.stateholder.sample
+
+import android.app.Application
+import io.github.rentoyokawa.stateholder.sample.data.UserRepository
+import io.github.rentoyokawa.stateholder.sample.di.generated.stateHolderModule_sample
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+/**
+ * DI ルート。KSP 生成の Koin モジュール（[stateHolderModule_sample]）と
+ * [UserRepository] の `single` 定義を読み込む。
+ *
+ * `stateHolderModule_sample` は `samples/android/build.gradle.kts` の
+ * `ksp { arg("stateholder.module.suffix", "sample"); arg("stateholder.module.package", ...) }`
+ * で固定したプロパティ名・パッケージから import している（KSP arg 未指定時は非決定 uniqueId になるため必須）。
+ */
+class SampleApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidContext(this@SampleApplication)
+            modules(
+                stateHolderModule_sample,
+                module { single { UserRepository() } },
+            )
+        }
+    }
+}

--- a/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/feature/UserDetailStateHolder.kt
+++ b/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/feature/UserDetailStateHolder.kt
@@ -1,5 +1,6 @@
 package io.github.rentoyokawa.stateholder.sample.feature
 
+import io.github.rentoyokawa.stateholder.annotations.StateHolder as StateHolderAnnotation
 import io.github.rentoyokawa.stateholder.core.SharedState
 import io.github.rentoyokawa.stateholder.core.StateHolder
 import io.github.rentoyokawa.stateholder.core.Store
@@ -15,7 +16,11 @@ import kotlinx.coroutines.flow.flowOf
 /**
  * 詳細側の StateHolder。読み側の [UserDetailStore] を保持し、
  * 書き側の [UserDetailAction] を実装して合成する。
+ *
+ * `@StateHolder` を付与し、KSP（stateholder-processor-koin）が
+ * [UserScreenViewModel] の Koin `factory { }` 定義を生成する対象にする（STA-14 成果の消費）。
  */
+@StateHolderAnnotation
 class UserDetailStateHolder(
     selectedUserId: SharedState<String?>,
     repository: UserRepository,

--- a/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/feature/UserListStateHolder.kt
+++ b/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/feature/UserListStateHolder.kt
@@ -1,5 +1,6 @@
 package io.github.rentoyokawa.stateholder.sample.feature
 
+import io.github.rentoyokawa.stateholder.annotations.StateHolder as StateHolderAnnotation
 import io.github.rentoyokawa.stateholder.core.SharedState
 import io.github.rentoyokawa.stateholder.core.StateHolder
 import io.github.rentoyokawa.stateholder.core.Store
@@ -12,7 +13,11 @@ import kotlinx.coroutines.flow.combine
 /**
  * 一覧側の StateHolder（= ViewModel の一片）。
  * 読み側の [UserListStore] を保持し、書き側の [UserListAction] を実装して合成する。
+ *
+ * `@StateHolder` を付与し、KSP（stateholder-processor-koin）が
+ * [UserScreenViewModel] の Koin `factory { }` 定義を生成する対象にする（STA-14 成果の消費）。
  */
+@StateHolderAnnotation
 class UserListStateHolder(
     private val selectedUserId: SharedState<String?>,
     repository: UserRepository,

--- a/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/feature/UserScreenViewModel.kt
+++ b/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/feature/UserScreenViewModel.kt
@@ -1,52 +1,25 @@
 package io.github.rentoyokawa.stateholder.sample.feature
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
-import io.github.rentoyokawa.stateholder.core.SharedState
 import io.github.rentoyokawa.stateholder.core.StateHolder
-import io.github.rentoyokawa.stateholder.sample.data.UserRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 /**
- * ViewModel は StateHolder を「コンストラクタで受け取り、公開するだけ」。
+ * ViewModel は具象 holder を「コンストラクタで受け取り、契約型で公開するだけ」。
  * ロジックは各 StateHolder（= ViewModel の一片）に分割されている。
  *
- * 消費側の型は契約 [StateHolder]<State, Action> のみ。Source は一切見えない。
+ * KSP（stateholder-processor-koin, STA-14）は本クラスのコンストラクタが
+ * `@StateHolder` 具象クラス（[UserListStateHolder] / [UserDetailStateHolder]）を
+ * 受け取ることを検出し、Koin `factory<UserScreenViewModel> { }` を生成する。
+ * DI は具象・View 境界（[userList] / [userDetail] の公開型）は契約という STA-13 の決定に従う。
+ *
+ * scope は生成 factory 内でローカルに作られ本 VM には渡らないため、
+ * scope の生成・破棄ライフサイクル（[[STA-15]]）は本チケットの範囲外。
  */
 class UserScreenViewModel(
-    val userList: StateHolder<UserListState, UserListAction>,
-    val userDetail: StateHolder<UserDetailState, UserDetailAction>,
-    private val holderScope: CoroutineScope,
+    userList: UserListStateHolder,
+    userDetail: UserDetailStateHolder,
 ) : ViewModel() {
 
-    override fun onCleared() {
-        holderScope.cancel()
-    }
-
-    companion object {
-        /**
-         * 組み立て（composition root）の手書き版。
-         * 将来はこの形のコードを KSP が生成する想定（STA-14）。
-         *
-         * - SharedState は「同一 ViewModel 内の holder 群で同一インスタンス」を結線
-         * - scope の生成・破棄の扱いは STA-15 で決定するまでの仮置き
-         *   （先に scope を作って holder に配り、ViewModel が onCleared で cancel する）
-         */
-        val Factory = viewModelFactory {
-            initializer {
-                val holderScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-                val selectedUserId = SharedState<String?>(null)
-                val repository = UserRepository()
-                UserScreenViewModel(
-                    userList = UserListStateHolder(selectedUserId, repository, holderScope),
-                    userDetail = UserDetailStateHolder(selectedUserId, repository, holderScope),
-                    holderScope = holderScope,
-                )
-            }
-        }
-    }
+    val userList: StateHolder<UserListState, UserListAction> = userList
+    val userDetail: StateHolder<UserDetailState, UserDetailAction> = userDetail
 }

--- a/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/ui/UserScreen.kt
+++ b/samples/android/src/main/kotlin/io/github/rentoyokawa/stateholder/sample/ui/UserScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.rentoyokawa.stateholder.core.StateHolder
 import io.github.rentoyokawa.stateholder.sample.feature.UserDetailAction
 import io.github.rentoyokawa.stateholder.sample.feature.UserDetailState
@@ -33,10 +32,11 @@ import io.github.rentoyokawa.stateholder.sample.feature.UserListAction
 import io.github.rentoyokawa.stateholder.sample.feature.UserListState
 import io.github.rentoyokawa.stateholder.sample.feature.UserScreenViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun UserScreen(
-    viewModel: UserScreenViewModel = viewModel(factory = UserScreenViewModel.Factory),
+    viewModel: UserScreenViewModel = koinViewModel(),
 ) {
     Row(Modifier.fillMaxSize()) {
         UserListPane(


### PR DESCRIPTION
## 概要
[STA-19](https://linear.app/rentoyokawa/issue/STA-19) — samples/android の ViewModel 組み立てを、手書き `viewModelFactory`（composition root）から KSP 生成の Koin モジュール（`stateholder-processor-koin`, STA-14 成果）に置き換える e2e 実証。

## ブランチ規約
- base: `impl/ksp`（**main ではない**。Stacked PR）
- CI（`pull_request: branches:[main]`）は base=impl/ksp では走らないため、検証はローカル gradle 実行に依拠する

## 主な変更（予定）
- `gradle/libs.versions.toml` に koin-android / koin-androidx-compose を追加
- `samples/android/build.gradle.kts` に ksp plugin + processor-koin 依存 + KSP arg（module 名/パッケージ固定）を追加
- 両 holder（`UserListStateHolder` / `UserDetailStateHolder`）に `@StateHolder` を付与
- `UserScreenViewModel` を具象 holder 受け取り・契約型公開へ変更し、手書き Factory を削除
- `SampleApplication` を新設し startKoin（生成モジュール + `UserRepository` の `single`）
- `UserScreen` を `koinViewModel()` 経由の VM 取得へ変更

## 実機/エミュレータ動作確認について
実機/エミュレータでの動作確認は自動検証の範囲外とし、**人間の verify レビューで行う**。

## 参照
- 実装計画: `~/Github/Loop/loop-vault/project-brain/StateHolder/flows/STA-19/plan.md`
- journal: `~/Github/Loop/loop-vault/project-brain/StateHolder/flows/STA-19/STA-19.md`